### PR TITLE
Change callback from services to api. Resolve #10

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var Widget = function () {
 		this.node = node;
 
 		includeJQueryIfNeeded(function () {
-			var url = 'https://services.shippify.co';
+			var url = 'https://api.shippify.co';
 			$.ajax({
 				method: 'GET',
 				url: url + '/shippify/widget',


### PR DESCRIPTION
The widget callback is changed:
from services.shippify.co 
to api.shippify.co
