### PR TITLE
Add language override

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ To test it, just copy this snippet into an `html` file or use the sample `html` 
       const orderManager = new shippify.integrations.OrderManager(orderTemplate, orderManagerOptions)
 
       const shippifyWidgetContainer = document.getElementById('my-shippify-widget')
-      const widget = new shippify.integrations.Widget(orderManager, shippifyWidgetContainer)
+      const widget = new shippify.integrations.Widget(orderManager, shippifyWidgetContainer, {
+        preferredLanguage: 'es'
+      })
     </script>
   </body>
 </html>

--- a/src/classes/Widget.js
+++ b/src/classes/Widget.js
@@ -4,7 +4,7 @@ import translations, { messageIds } from './../translations'
 import widgetTemplate from './../widget.ejs'
 
 class Widget {
-  constructor(orderManager, node, { excludedFields = [] } = {}) {
+  constructor(orderManager, node, { excludedFields = [], preferredLanguage } = {}) {
     if (!(orderManager instanceof OrderManager)) {
       throw generateError(errors.invalidValue('orderManager', orderManager))
     }
@@ -14,14 +14,17 @@ class Widget {
     if (!Array.isArray(excludedFields)) {
       throw generateError(errors.invalidValue('options.excludedFields', excludedFields))
     }
+    if (typeof preferredLanguage !== 'undefined' && typeof preferredLanguage !== 'string') {
+      throw generateError(errors.invalidValue('options.preferredLanguage', preferredLanguage))
+    }
     this.orderManager = orderManager
     this.node = node
     this.order = {
       contact: {}
     }
-    const preferredLanguage = (navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage
-    const preferredLanguageTwoLetterCode = preferredLanguage.includes('-') ? preferredLanguage.split('-')[0] : preferredLanguage
-    const language = Object.keys(translations).indexOf(preferredLanguageTwoLetterCode) !== -1 ? preferredLanguageTwoLetterCode : 'en'
+    const navigatorLanguage = preferredLanguage || (navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage
+    const languageTwoLetterCode = navigatorLanguage.includes('-') ? navigatorLanguage.split('-')[0] : navigatorLanguage
+    const language = Object.keys(translations).indexOf(languageTwoLetterCode) !== -1 ? languageTwoLetterCode : 'en'
     this.node.innerHTML = widgetTemplate({ excludedFields, messageIds, messages: translations[language] })
 
     const { document, google } = window

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,11 @@ const orderManagerOptions = {
    apiSecret: 'my-shippify-api-secret'
   },
   // googleMapsAPIKey: 'my-google-maps-api-key'
+
 }
 const orderManager = new shippify.integrations.OrderManager(orderTemplate, orderManagerOptions)
 
 const shippifyWidgetContainer = document.getElementById('root')
-const widget = new shippify.integrations.Widget(orderManager, shippifyWidgetContainer)
+const widget = new shippify.integrations.Widget(orderManager, shippifyWidgetContainer, {
+  // preferredLanguage: 'es'
+})


### PR DESCRIPTION
Allow the widget to override the language, at instance time, through the options field `preferredLanguage`. This will ignore the browser's language and set the messages with the provided language code.